### PR TITLE
Update terraform.tf aws provider version

### DIFF
--- a/terraform.tf
+++ b/terraform.tf
@@ -11,7 +11,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.28.0"
+      version = "~> 5.26.0"
     }
   }
 


### PR DESCRIPTION
Provider registry.terraform.io/hashicorp/aws v3.28.0 does not have a package available for your current platform, darwin_arm64 which prevent from successful init from Macs with  new ARM chips